### PR TITLE
Added image alignment capabilities to editable areas

### DIFF
--- a/packages/thriver-core-styles/lib/styles/type.import.less
+++ b/packages/thriver-core-styles/lib/styles/type.import.less
@@ -88,7 +88,7 @@ ul, ol{
 }
 
 // Markdown
-.markdown, .eventContainer .main{
+.markdown, .eventContainer .main, [data-editable=true]{
     p{float: none;}
     // Image defaults
     img{


### PR DESCRIPTION
Instead of adding class `markdown` to said sections. We see other editable sections in the tabs view. If `[data-editable=true]` : Then we can align images with our said method.