### PR TITLE
H2 elements under profile tab should not be editable

### DIFF
--- a/packages/thriver-core-components/lib/component-tabs/admin.js
+++ b/packages/thriver-core-components/lib/component-tabs/admin.js
@@ -133,7 +133,7 @@ Template.tabs.events({
    * @method
    *   @param {$.Event} event - jQuery Event handle
    */
-  'click [editable!="false"] h2': (event) => {
+  'click article[data-editable="true"] h2': (event) => {
     check(event, $.Event);
 
     event.preventDefault();


### PR DESCRIPTION
Double-clicking header > h2 elements across the website, such as under the profile tab in the account section, causes the elements to become editable.  That functionality should only be available in the get involved and who we are sections.